### PR TITLE
- 정보 제공에 동의한 유저가 연령별 / 성별에 따른 평균 지출 조회 기능 구현

### DIFF
--- a/src/mobile-receipt/user/etc/age_avg.sql
+++ b/src/mobile-receipt/user/etc/age_avg.sql
@@ -1,0 +1,38 @@
+DELIMITER //
+
+CREATE PROCEDURE GetUserSpending(IN userId VARCHAR(30))
+BEGIN
+    DECLARE alarmStatus CHAR(1);
+
+    -- 유저의 정보 제공 동의 여부 조회
+    SELECT is_alarm_enabled INTO alarmStatus FROM user WHERE user_id = userId;
+
+    -- 정보 제공 동의하지 않으면 에러 발생
+    IF alarmStatus != 'Y' THEN
+        SIGNAL SQLSTATE '45000'
+        SET MESSAGE_TEXT = '정보 제공에 동의하지 않은 유저입니다.';
+    END IF;
+
+    -- 동의한 경우에만 소비 내역 조회
+    SELECT 
+        CASE
+            WHEN u.age BETWEEN 10 AND 19 THEN '10대'
+            WHEN u.age BETWEEN 20 AND 29 THEN '20대'
+            WHEN u.age BETWEEN 30 AND 39 THEN '30대'
+            WHEN u.age BETWEEN 40 AND 49 THEN '40대'
+            WHEN u.age BETWEEN 50 AND 59 THEN '50대'
+            ELSE '기타'
+        END AS 연령대,
+        FLOOR(AVG(r.amount)) AS 평균소비금액
+    FROM receipt r
+    JOIN user u ON r.user_id = u.user_id
+    WHERE u.user_id = userId
+      AND r.created_at BETWEEN '2025-01-01 00:00:00' AND '2025-02-29 23:59:59'
+      AND r.is_canceled = 'N'
+      AND r.transaction_status = '승인';
+END //
+
+DELIMITER ;
+
+
+CALL GetUserSpending('user09');

--- a/src/mobile-receipt/user/etc/category_avg.sql
+++ b/src/mobile-receipt/user/etc/category_avg.sql
@@ -1,0 +1,20 @@
+-- 카테고리 별 기간 내 평균 소비 금액
+
+SELECT c.category_name	AS category
+     , FLOOR(AVG(r.amount))	AS '기간 내 평균 소비 금액'
+  FROM receipt r
+  JOIN store s ON r.store_id = s.store_id
+  JOIN category c ON s.category_id = c.category_id
+ WHERE s.category_id = '1'
+   AND r.created_at BETWEEN '2025-01-01 00:00:00' AND '2025-02-29 23:59:59'
+   AND r.is_canceled = 'N'
+   AND r.transaction_status = '승인'
+   AND r.user_id = 'user01'
+ GROUP BY c.category_name;
+
+
+
+
+
+
+

--- a/src/mobile-receipt/user/etc/compare_monthly_receipt.sql
+++ b/src/mobile-receipt/user/etc/compare_monthly_receipt.sql
@@ -1,0 +1,66 @@
+SELECT 
+    user_id, -- 유저 ID 추가
+    SUM(CASE
+        WHEN created_at >= DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')
+         AND created_at < DATE_ADD(DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'), INTERVAL 1 MONTH)
+        THEN amount ELSE 0 END) AS '이번달 소비 내역',
+    
+    SUM(CASE
+        WHEN created_at >= DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 1 MONTH), '%Y-%m-01')
+         AND created_at < DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')
+        THEN amount ELSE 0 END) AS '지난달 소비 내역',
+
+    (SUM(CASE
+        WHEN created_at >= DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')
+         AND created_at < DATE_ADD(DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'), INTERVAL 1 MONTH)
+        THEN amount ELSE 0 END)
+    - SUM(CASE
+        WHEN created_at >= DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 1 MONTH), '%Y-%m-01')
+         AND created_at < DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')
+        THEN amount ELSE 0 END)) AS '지출 차이',
+
+    COUNT(CASE
+        WHEN created_at >= DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')
+         AND created_at < DATE_ADD(DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'), INTERVAL 1 MONTH)
+        THEN 1 END) AS '이번달 거래 건수',
+
+    COUNT(CASE
+        WHEN created_at >= DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 1 MONTH), '%Y-%m-01')
+         AND created_at < DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')
+        THEN 1 END) AS '지난달 거래 건수',
+
+    MAX(CASE
+        WHEN created_at >= DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')
+         AND created_at < DATE_ADD(DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'), INTERVAL 1 MONTH)
+        THEN amount END) AS '이번달 최대 지출',
+
+    MAX(CASE
+        WHEN created_at >= DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 1 MONTH), '%Y-%m-01')
+         AND created_at < DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')
+        THEN amount END) AS '지난달 최대 지출',
+
+    MIN(CASE
+        WHEN created_at >= DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')
+         AND created_at < DATE_ADD(DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'), INTERVAL 1 MONTH)
+        THEN amount END) AS '이번달 최소 지출',
+
+    MIN(CASE
+        WHEN created_at >= DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 1 MONTH), '%Y-%m-01')
+         AND created_at < DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')
+        THEN amount END) AS '지난달 최소 지출',
+
+    FLOOR(AVG(CASE
+        WHEN created_at >= DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')
+         AND created_at < DATE_ADD(DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01'), INTERVAL 1 MONTH)
+        THEN amount END)) AS '이번달 평균 지출',
+
+    FLOOR(AVG(CASE
+        WHEN created_at >= DATE_FORMAT(DATE_SUB(CURRENT_DATE(), INTERVAL 1 MONTH), '%Y-%m-01')
+         AND created_at < DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')
+        THEN amount END)) AS '지난달 평균 지출'
+
+FROM receipt
+WHERE is_canceled = 'N'
+  AND transaction_status = '승인'
+  AND user_id = 'user01'
+GROUP BY user_id; -- 유저별로 데이터를 그룹화하여 출력

--- a/src/mobile-receipt/user/etc/gender_avg.sql
+++ b/src/mobile-receipt/user/etc/gender_avg.sql
@@ -1,0 +1,34 @@
+DELIMITER $$
+
+CREATE PROCEDURE GetGenderSpending(IN userId VARCHAR(50))
+BEGIN
+    DECLARE alarmStatus CHAR(1);
+    DECLARE userGender VARCHAR(10);
+
+    -- 유저 정보 제공 동의 여부 확인
+    SELECT is_alarm_enabled, gender INTO alarmStatus, userGender 
+    FROM user 
+    WHERE user_id = userId;
+
+    -- 정보 제공에 동의하지 않은 경우 에러 발생
+    IF alarmStatus != 'Y' THEN
+        SIGNAL SQLSTATE '45000'
+        SET MESSAGE_TEXT = '정보 제공에 동의하지 않은 유저입니다.';
+    END IF;
+
+    -- 동의한 경우에만 해당 성별 소비 내역 조회
+    SELECT 
+        u.gender AS 성별,
+        FLOOR(AVG(r.amount)) AS 평균소비금액
+    FROM receipt r
+    JOIN user u ON r.user_id = u.user_id
+    WHERE r.created_at BETWEEN '2025-01-01' AND '2025-02-29'  -- 2월 31일 → 2월 29일로 수정
+      AND r.is_canceled = 'N'
+      AND r.transaction_status = '승인'
+      AND u.gender = userGender  -- 입력받은 유저의 성별을 기준으로 필터링
+    GROUP BY u.gender;
+END $$
+
+DELIMITER ;
+
+CALL GetGenderSpending('user09');


### PR DESCRIPTION
- 유저가 카테고리별 평균 소비 금액 조회 기능 구현
- 전월 기준 소비 금액 변화와 소비량 분석 기능 구현

## #️⃣ 관련 이슈 번호

Close #63

## 📝 설명
정보 제공에 동의한 유저가 연령별 / 성별에 따른 평균 지출 조회 기능 구현
유저가 카테고리별 평균 소비 금액 조회 기능 구현
전월 기준 소비 금액 변화와 소비량 분석 기능 구현

### 구현 내용
- 연령별 평균 소비 금액 조회 (정보 제공에 동의한 유저에 한해서 조회 가능 / 동의하지 않으면 오류 메세지 출력)
- 성별에 따른 평균 소비 금액 조회 (정보 제공에 동의한 유저에 한해서 조회 가능 / 동의하지 않으면 오류 메세지 출력)
- 카테고리 별 평균 소비 금액 조회 기능 구현
- 전월 기준 소비 금액 변화와 소비량 분석 기능 구현

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 데이터베이스 코딩 컨벤션에 맞게 작성했습니다.
